### PR TITLE
HTTP Error codes

### DIFF
--- a/avwx_api/api.py
+++ b/avwx_api/api.py
@@ -91,10 +91,13 @@ class Endpoint(Resource):
 
         resp = handle_report(rtype, station, options, nofail)
 
+        # if any, use the http code from the dict
+        status_code = resp.pop("Code", 200)
+
         response = self.format_response(resp, rtype)
         
-        # if any, use the http code from the response
-        response.status_code = resp.get("Code", 200)
+        response.status_code = status_code
+    
         return response
 
 class ReportEndpoint(Endpoint):

--- a/avwx_api/api.py
+++ b/avwx_api/api.py
@@ -88,8 +88,14 @@ class Endpoint(Resource):
         if error:
             return jsonify({'Error': error})
         nofail = self.get_param('onfail') == 'cache'
+
         resp = handle_report(rtype, station, options, nofail)
-        return self.format_response(resp, rtype)
+
+        response = self.format_response(resp, rtype)
+        
+        # if any, use the http code from the response
+        response.status_code = resp.get("Code", 200)
+        return response
 
 class ReportEndpoint(Endpoint):
     """Standard report endpoint"""

--- a/avwx_api/handling.py
+++ b/avwx_api/handling.py
@@ -58,10 +58,10 @@ def new_report(rtype: str, station: str, report: str) -> {str: object}:
             parser.update()
         except avwx.exceptions.InvalidRequest as exc:
             print('Invalid Request:', exc)
-            return {'Error': ERRORS[0].format(rtype.upper(), station)}
+            return {'Error': ERRORS[0].format(rtype.upper(), station), 'Code': 404}
         except Exception as exc:
             print('unknown Error', exc)
-            return {'Error': ERRORS[0].format(rtype.upper(), station)}
+            return {'Error': ERRORS[0].format(rtype.upper(), station), 'Code': 404}
     else:
         parser.update(report)
     # Retrieve report data

--- a/avwx_api/handling.py
+++ b/avwx_api/handling.py
@@ -109,9 +109,16 @@ def handle_report(rtype: str, loc: [str], opts: [str], nofail: bool = False) -> 
         #Do things given only station
         station = loc[0].upper()
         report = None
+
+    resp = {'Meta': {'Timestamp': datetime.utcnow()}}        
     # Fetch an existing and up-to-date cache or make a new report
-    data = CACHE.get(rtype, station) or new_report(rtype, station, report)
-    resp = {'Meta': {'Timestamp': datetime.utcnow()}}
+    try:
+        data = CACHE.get(rtype, station) or new_report(rtype, station, report)
+    except avwx.exceptions.BadStation as e:
+        resp["Error"] = str(e)
+        resp["Code"] = 400
+        return resp
+    
     if 'timestamp' in data:
         resp['Meta']['Cache-Timestamp'] = data['timestamp']
     # Handle errors according to nofail arguement


### PR DESCRIPTION
fixes #1 

- `HTTP 400` instead of `500` when the icao code is invalid
- `HTTP 404` instead of `200` no metar is found for a valid icao. 

I've added an optional`Code` key in the dictionaries returned from the `handling.py` which are set as the http return codes.
