### PR TITLE
Replace $ keys in cache

### DIFF
--- a/avwx_api/cache.py
+++ b/avwx_api/cache.py
@@ -28,6 +28,19 @@ class Cache(object):
         """Returns True if a datetime is older than the number of minutes given"""
         return datetime.utcnow() > time + timedelta(minutes=minutes)
 
+    @staticmethod
+    def replace_keys(in_dict, key, by_key):
+        """ Replaces recurively the keys equal to 'key' by 'by_key' 
+
+        Some keys in the METAR are '$' and this is not accepted by mongodb
+        """    
+        for k, v in in_dict.items():
+            if k == key:
+                print("Replacing {} by {}".format(key, by_key))
+                in_dict[by_key] = in_dict.pop(key)
+            if isinstance(v, dict):
+                Cache.replace_keys(v, key, by_key)        
+
     def get(self, rtype: str, station: str, force: bool = False) -> {str: object}:
         """Returns the current cached data for a report type and station or None
 
@@ -37,6 +50,9 @@ class Cache(object):
         if not MONGO_URI:
             return
         data = self.tables[rtype].find_one({'_id': station})
+
+        Cache.replace_keys(data, '_$', '$')
+
         if force or (isinstance(data, dict) and not self.has_expired(data['timestamp'])):
             return data
 
@@ -45,4 +61,7 @@ class Cache(object):
         if not MONGO_URI:
             return
         data['timestamp'] = datetime.utcnow()
+
+        Cache.replace_keys(data, '$', '_$')
+
         self.tables[rtype].update({'_id': data['data']['Station']}, data, upsert=True)


### PR DESCRIPTION
Before serialising to mongo, travers recursively the data and replace any `$` keys by `_$` and vice versa when deserialising. 


fixes #2