### PR TITLE
Fixed hypercorn config

### DIFF
--- a/hypercorn_config.py
+++ b/hypercorn_config.py
@@ -2,7 +2,7 @@
 Hypercorn application server settings
 """
 
-host = "0.0.0.0"
-port = 8000
+bind = "0.0.0.0:8000"
+
 
 workers = 4


### PR DESCRIPTION
Hi 👋 

it seems the hypercorn config did not have the proper format and the current values are ignored. According to [the doc](https://pgjones.gitlab.io/hypercorn/source/hypercorn.config.html) it should be `bind` instead of `port` and `host`

cheers